### PR TITLE
[Kamil Markow] [393] Disable autocomplete on forms

### DIFF
--- a/src/client/cases/CaseDetails/CivilianDialog/AddressAutoSuggest.js
+++ b/src/client/cases/CaseDetails/CivilianDialog/AddressAutoSuggest.js
@@ -103,7 +103,8 @@ class AddressAutoSuggest extends Component {
             input: classes.input
           },
           "data-test": dataTest,
-          ...other
+          ...other,
+          autoComplete: 'disabled', // "off" does not work on chrome
         }}
         error={shouldRenderError}
         helperText={reduxFormMeta.error}

--- a/src/client/cases/CaseDetails/CivilianDialog/CivilianDialog.js
+++ b/src/client/cases/CaseDetails/CivilianDialog/CivilianDialog.js
@@ -181,7 +181,7 @@ class CivilianDialog extends Component {
               >
                 OR
               </Typography>
-              <EmailField name="email" />
+              <EmailField name="email" autoComplete="disabled" />
             </div>
             <div style={{ marginBottom: "16px" }}>
               <AddressInput

--- a/src/client/cases/sharedFormComponents/AddressSecondLine.js
+++ b/src/client/cases/sharedFormComponents/AddressSecondLine.js
@@ -11,6 +11,7 @@ const AddressSecondLine = ({ label, fieldName, style }) => {
       style={style}
       inputProps={{
         "data-test": "streetAddress2Input",
+        autoComplete: 'disabled', // "off" does not work on chrome
         maxLength: 25
       }}
       InputLabelProps={{

--- a/src/client/cases/sharedFormComponents/EmailField.js
+++ b/src/client/cases/sharedFormComponents/EmailField.js
@@ -12,6 +12,7 @@ const EmailField = props => (
     data-test="emailField"
     validate={[isEmail]}
     style={{ marginRight: "5%", marginBottom: "3%" }}
+    props={{ autoComplete: props.autoComplete }}
   />
 );
 


### PR DESCRIPTION
I found 3 fields that were being autocompleted:

1. Email field was showing previously used values in this field including personal emails
2. Address field was trying to use autofill from saved addresses
3. Street2 field was trying to use autofill from saved addresses

Chrome is trying to autofill as much as it can and it ignores autoComplete set to `off`. It does not ignore `disabled`.

I did not include any unit tests because it's a simple property change to a hardcoded values and I usually try to avoiding testing static properties in tests. It makes the properties easier to change as needed without having to update tests. However if you would like to have a unit test let me know and I will add them.

Tested on `chrome Version 71.0.3578.98 (Official Build) (64-bit)`