### PR TITLE
issue #513 - split address recipient into name, address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.vscode/
 .idea/
 *.iml
 /selenium-debug.log

--- a/src/client/cases/ReferralLetter/LetterPreview/LetterPreview.js
+++ b/src/client/cases/ReferralLetter/LetterPreview/LetterPreview.js
@@ -221,8 +221,15 @@ class LetterPreview extends Component {
         >
           <CardContent>
             <Field
+              name="recipient_field.name"
+              component={TextField}
+              label="Title and Name"
+              fullWidth
+              style={{ marginBottom: "16px" }}
+            />
+            <Field
               style={{ flex: 4 }}
-              name="recipient"
+              name="recipient_field.address"
               component={TextField}
               label="Address To"
               fullWidth

--- a/src/client/cases/ReferralLetter/LetterPreview/LetterPreview.test.js
+++ b/src/client/cases/ReferralLetter/LetterPreview/LetterPreview.test.js
@@ -84,7 +84,11 @@ describe("LetterPreview", function() {
         "Letter Preview HTML",
         {
           sender: "bob",
-          recipient: "jane",
+          recipient: "jane\naddress",
+          recipient_field: {
+            name: "jane",
+            address: "address",
+          },
           transcribedBy: "joe"
         },
         EDIT_STATUS.GENERATED,
@@ -118,7 +122,11 @@ describe("LetterPreview", function() {
     button.simulate("click");
     const expectedFormValues = {
       sender: "bob",
-      recipient: "jane",
+      recipient: "jane\naddress",
+      recipient_field: {
+        name: "jane",
+        address: "address",
+      },
       transcribedBy: "joe"
     };
     expect(dispatchSpy).toHaveBeenCalledWith(
@@ -135,7 +143,11 @@ describe("LetterPreview", function() {
     button.simulate("click");
     const expectedFormValues = {
       sender: "bob",
-      recipient: "jane",
+      recipient: "jane\naddress",
+      recipient_field: {
+        name: "jane",
+        address: "address",
+      },
       transcribedBy: "joe"
     };
     expect(dispatchSpy).toHaveBeenCalledWith(
@@ -149,7 +161,11 @@ describe("LetterPreview", function() {
     backButton.simulate("click");
     const expectedFormValues = {
       sender: "bob",
-      recipient: "jane",
+      recipient: "jane\naddress",
+      recipient_field: {
+        name: "jane",
+        address: "address",
+      },
       transcribedBy: "transcriber"
     };
     expect(dispatchSpy).toHaveBeenCalledWith(
@@ -231,7 +247,11 @@ describe("LetterPreview", function() {
     submitForReviewButton.simulate("click");
     const expectedFormValues = {
       sender: "bob",
-      recipient: "jane",
+      recipient: "jane\naddress",
+      recipient_field: {
+        name: "jane",
+        address: "address",
+      },
       transcribedBy: "joe"
     };
     expect(dispatchSpy).toHaveBeenCalledWith(
@@ -463,7 +483,11 @@ describe("LetterPreview", function() {
     reviewAndApproveButton.simulate("click");
     const expectedFormValues = {
       sender: "bob",
-      recipient: "jane",
+      recipient: "jane\naddress",
+      recipient_field: {
+        name: "jane",
+        address: "address",
+      },
       transcribedBy: "transcriber"
     };
     expect(dispatchSpy).toHaveBeenCalledWith(
@@ -480,7 +504,11 @@ describe("LetterPreview", function() {
     beforeEach(function() {
       expectedFormValues = {
         sender: "bob",
-        recipient: "jane",
+        recipient: "jane\naddress",
+        recipient_field: {
+          name: "jane",
+          address: "address",
+        },
         transcribedBy: "joe"
       };
     });
@@ -561,7 +589,11 @@ describe("LetterPreview", function() {
         "Letter Preview HTML Edited",
         {
           sender: "bob",
-          recipient: "jane",
+          recipient: "jane\naddress",
+          recipient_field: {
+            name: "jane",
+            address: "address",
+          },
           transcribedBy: "joe"
         },
         EDIT_STATUS.EDITED,
@@ -585,7 +617,11 @@ describe("LetterPreview", function() {
         caseId,
         {
           sender: "bob",
-          recipient: "jane",
+          recipient: "jane\naddress",
+          recipient_field: {
+            name: "jane",
+            address: "address",
+          },
           transcribedBy: "joe"
         },
         `/cases/${caseId}/letter/edit-letter`
@@ -599,7 +635,11 @@ describe("LetterPreview", function() {
         "Letter Preview HTML",
         {
           sender: "bob",
-          recipient: "jane",
+          recipient: "jane\naddress",
+          recipient_field: {
+            name: "jane",
+            address: "address",
+          },
           transcribedBy: "joe"
         },
         EDIT_STATUS.EDITED,
@@ -670,7 +710,11 @@ describe("LetterPreview", function() {
         "Letter Preview HTML Edited",
         {
           sender: "bob",
-          recipient: "jane",
+          recipient: "jane\naddress",
+          recipient_field: {
+            name: "jane",
+            address: "address",
+          },
           transcribedBy: "joe"
         },
         EDIT_STATUS.EDITED,

--- a/src/client/cases/ReferralLetter/ReviewAndApproveLetter/ReviewAndApproveLetter.test.js
+++ b/src/client/cases/ReferralLetter/ReviewAndApproveLetter/ReviewAndApproveLetter.test.js
@@ -74,7 +74,15 @@ describe("ReviewAndApproveLetter", () => {
   test("should display today's date when letter is generated", () => {
     const displayDate = wrapper.find('[data-test="edit-history"]').first();
     const letterHtml = "<p>html</p>";
-    const addresses = "<p>addresses</p>";
+    const addresses = {
+      recipient: "name\naddress",
+      recipient_field: {
+        address: "address",
+        name: "name",
+      },
+      sender: "some sender",
+      transcribedBy: "transcriber"
+    };
     store.dispatch(
       getReferralLetterPreviewSuccess(
         letterHtml,
@@ -90,7 +98,15 @@ describe("ReviewAndApproveLetter", () => {
 
   test("should show approve button when in ready for review status", async () => {
     const letterHtml = "<p>html</p>";
-    const addresses = "<p>addresses</p>";
+    const addresses = {
+      recipient: "name\naddress",
+      recipient_field: {
+        address: "address",
+        name: "name",
+      },
+      sender: "some sender",
+      transcribedBy: "transcriber"
+    };
     const inputDate = "2018-11-20T21:59:40.707Z";
     store.dispatch(
       getCaseDetailsSuccess({
@@ -117,7 +133,15 @@ describe("ReviewAndApproveLetter", () => {
 
   test("should display last edit history date when in ready for review status", async () => {
     const letterHtml = "<p>html</p>";
-    const addresses = "<p>addresses</p>";
+    const addresses = {
+      recipient: "name\naddress",
+      recipient_field: {
+        address: "address",
+        name: "name",
+      },
+      sender: "some sender",
+      transcribedBy: "transcriber"
+    };
     const inputDate = "2018-11-20T21:59:40.707Z";
     store.dispatch(
       getCaseDetailsSuccess({

--- a/src/client/cases/ReferralLetter/thunks/editReferralLetterAddresses.js
+++ b/src/client/cases/ReferralLetter/thunks/editReferralLetterAddresses.js
@@ -1,6 +1,7 @@
 import { push } from "connected-react-router";
 import axios from "axios/index";
 import { snackbarSuccess } from "../../../actionCreators/snackBarActionCreators";
+import { assembleAddressRecipient } from "../../../utilities/fabricateAddressRecipient";
 
 const editReferralLetterAddresses = (
   caseId,
@@ -10,6 +11,7 @@ const editReferralLetterAddresses = (
   alternativeFailureCallback
 ) => async dispatch => {
   try {
+    addressData.recipient = assembleAddressRecipient(addressData.recipient_field);
     await axios.put(
       `api/cases/${caseId}/referral-letter/addresses`,
       addressData

--- a/src/client/cases/ReferralLetter/thunks/editReferralLetterAddresses.test.js
+++ b/src/client/cases/ReferralLetter/thunks/editReferralLetterAddresses.test.js
@@ -13,7 +13,11 @@ describe("editReferralLetterAddresses", () => {
   const dispatch = jest.fn();
   configureInterceptors({ dispatch });
   const addressData = {
-    recipient: "bob",
+    recipient: "bob\naddress",
+    recipient_field: {
+      name: "bob",
+      address: "address",
+    },
     sender: "jane",
     transcribedBy: "smith"
   };

--- a/src/client/reducers/cases/referralLetterReducer.js
+++ b/src/client/reducers/cases/referralLetterReducer.js
@@ -4,6 +4,8 @@ import {
   GET_REFERRAL_LETTER_EDIT_STATUS_SUCCESS,
   GET_REFERRAL_LETTER_SUCCESS
 } from "../../../sharedUtilities/constants";
+import { disassembleAddressRecipient 
+} from "../../../client/utilities/fabricateAddressRecipient";
 
 const initialState = {
   letterPdf: null,
@@ -23,7 +25,7 @@ const referralLetterReducer = (state = initialState, action) => {
       return {
         ...state,
         letterHtml: action.letterHtml,
-        addresses: action.addresses,
+        addresses: {...action.addresses, recipient_field: disassembleAddressRecipient(action.addresses.recipient)},
         editStatus: action.editStatus,
         lastEdited: action.lastEdited,
         finalFilename: action.finalFilename,

--- a/src/client/reducers/cases/referralLetterReducer.test.js
+++ b/src/client/reducers/cases/referralLetterReducer.test.js
@@ -64,7 +64,11 @@ describe("referralLetterReducer", () => {
         letterPdf: null
       };
       let referralLetterAddresses = {
-        recipient: "recipient",
+        recipient: "name\naddress",
+        recipient_field: {
+          address: "address",
+          name: "name",
+        },
         sender: "some sender",
         transcribedBy: "transcriber"
       };
@@ -151,6 +155,97 @@ describe("referralLetterReducer", () => {
       };
 
       expect(newState).toEqual(expectedState);
+    });
+  });
+
+  describe("address recipient fields", () => {
+    test("sets the recipient fields from the recipient string", () => {
+      const timeOfEdit = new Date("2018-07-01 19:00:22 CDT");
+      timekeeper.freeze(timeOfEdit);
+      const initialState = {
+        letterDetails: "something",
+        letterHtml: "something",
+        addresses: {},
+        editStatus: null,
+        lastEdited: null,
+        finalFilename: null,
+        draftFilename: null,
+        letterPdf: null
+      };
+      let originalReferralLetterAddresses = {
+        recipient: "name\naddress",
+        sender: "some sender",
+        transcribedBy: "transcriber"
+      };
+      let updatedReferralLetterAddresses = {
+        ...originalReferralLetterAddresses, 
+        recipient_field: {
+          name: "name",
+          address: "address",
+        }
+      }
+      let newState = referralLetterReducer(
+        initialState,
+        getReferralLetterPreviewSuccess(
+          "new letter html",
+          originalReferralLetterAddresses,
+          EDIT_STATUS.EDITED,
+          timeOfEdit,
+          "final_filename.pdf",
+          "draft_filename.pdf"
+        )
+      );
+      expect(newState.addresses).toEqual(updatedReferralLetterAddresses);
+
+      originalReferralLetterAddresses = {
+        recipient: "name",
+        sender: "some sender",
+        transcribedBy: "transcriber"
+      };
+      updatedReferralLetterAddresses = {
+        ...originalReferralLetterAddresses, 
+        recipient_field: {
+          name: "name",
+          address: "",
+        }
+      }
+      newState = referralLetterReducer(
+        initialState,
+        getReferralLetterPreviewSuccess(
+          "new letter html",
+          originalReferralLetterAddresses,
+          EDIT_STATUS.EDITED,
+          timeOfEdit,
+          "final_filename.pdf",
+          "draft_filename.pdf"
+        )
+      );
+      expect(newState.addresses).toEqual(updatedReferralLetterAddresses);
+
+      originalReferralLetterAddresses = {
+        recipient: "",
+        sender: "some sender",
+        transcribedBy: "transcriber"
+      };
+      updatedReferralLetterAddresses = {
+        ...originalReferralLetterAddresses, 
+        recipient_field: {
+          name: "",
+          address: "",
+        }
+      }
+      newState = referralLetterReducer(
+        initialState,
+        getReferralLetterPreviewSuccess(
+          "new letter html",
+          originalReferralLetterAddresses,
+          EDIT_STATUS.EDITED,
+          timeOfEdit,
+          "final_filename.pdf",
+          "draft_filename.pdf"
+        )
+      );
+      expect(newState.addresses).toEqual(updatedReferralLetterAddresses);
     });
   });
 });

--- a/src/client/utilities/fabricateAddressRecipient.js
+++ b/src/client/utilities/fabricateAddressRecipient.js
@@ -1,0 +1,22 @@
+import {nullifyFieldUnlessValid} from './fieldNormalizers'
+
+
+export const assembleAddressRecipient = ({name, address}) => {
+  let recipient = '';
+  if( typeof field === 'object' ) {
+    recipient = (name.trim() + '\n' + address).trim();
+  }
+  return recipient;
+}
+
+export const disassembleAddressRecipient = (recipient) => {
+  let name = '', address = '';
+  if( nullifyFieldUnlessValid(recipient) ) {
+    // handle edge case: recipient is a single line with no \n
+    let normalized_recipient = recipient + '\n';
+    const indexOfFirstLine = normalized_recipient.indexOf('\n');
+    name    = normalized_recipient.slice(0, indexOfFirstLine);
+    address = normalized_recipient.slice(indexOfFirstLine+1).trimEnd();
+  }
+  return {name, address};
+}


### PR DESCRIPTION
Given    I have chang the title and name field from the pre-populated name to someone new AND I leave the "Address To" info as it is
When     I am viewing the letter for approval or a downloaded PDF of the letter 
Then    I will see the new input as the salutation line and also the title/name displayed at the top of each subsequent page (pg 2 and beyond) AND the new input will be atop the address info and the address info will be the same as the pre-populated value since it was unchanged