### PR TITLE
Capture Run Times for Newman Letter-Generation Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,7 @@ jobs:
       - image: postman/newman:latest
     steps:
       - checkout
+      - run: mkdir /tmp/output
       - run:
           name: Run Letter Integration Tests
           command: |
@@ -207,7 +208,33 @@ jobs:
             -e doc/postman/CI.postman_environment.json \
             --env-var client_id=$CI_AUTH0_CLIENT_ID \
             --env-var client_secret=$CI_AUTH0_CLIENT_SECRET \
-            doc/postman/Police\ Data\ Management.postman_collection.json
+            doc/postman/Police\ Data\ Management.postman_collection.json > /tmp/output/newman-result.txt
+      - run:
+          name: Test Results
+          command: cat /tmp/output/newman-result.txt
+      - persist_to_workspace:
+          root: '/tmp'
+          paths:
+            - output/newman-result.txt
+  
+  letter-generation-ci-latency-check:
+    docker:
+      - image: node:latest
+    steps:
+      - run:
+          name: Install Git
+          command: apt-get update && apt-get install git --assume-yes
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Capture Test Output as CSV
+          command: scripts/extractTestLatency.sh > output/letter-generation-test-stats.csv
+      - run:
+          name: Assert on Test Latency
+          command: node scripts/assertOnTestLatency.js
+      - store_artifacts:
+          path: output/
 
   deploy-ci:
     docker:
@@ -502,9 +529,13 @@ workflows:
       - letter-generation-testing-ci:
           requires:
             - ensure-ci-deploy-succeeded
+      - letter-generation-ci-latency-check:
+          requires:
+            - letter-generation-testing-ci
       - e2e-testing-ci-pdm:
           requires:
             - letter-generation-testing-ci
+  
   build_and_deploy_release:
     jobs:
       - security-check:

--- a/scripts/assertOnTestLatency.js
+++ b/scripts/assertOnTestLatency.js
@@ -1,0 +1,80 @@
+const fs = require("fs");
+
+// set a specific threshold (in ms) for an operation, otherwise DEFAULT will be used
+// current thresholds were set to 10% above the runtime of a baseline test run
+const THRESHOLDS = {
+  // Case
+  ["Create Case"]: 283,
+  ["Delete Case"]: 53,
+  ["Update Case to Restored"]: 73,
+  ["Update Case Narrative"]: 283,
+  ["Update Case Status"]: 323,
+  // Case Tag
+  ["Create Case Tag"]: 178,
+  ["Retrieve Case Tags"]: 56,
+  ["Delete Case Tag"]: 110,
+  // Case Note
+  ["Create Case Note"]: 338,
+  ["Retrieve Case Notes"]: 297,
+  ["Delete Case Note"]: 229,
+  // Notification
+  ["Retrieve Notifications"]: 155,
+  ["Retrieve Notification Status"]: 36,
+  ["Update Notification as Read"]: 141,
+  // Case Officer
+  ["Create Case Officer"]: 464,
+  ["Create Case Officer Allegation"]: 298,
+  ["Update Officer History"]: 92,
+  // Referral Letter
+  ["Retrieve Referral Letter"]: 140,
+  ["Update Referral Letter Classifications"]: 79,
+  ["Retrieve Referral Letter Preview"]: 645,
+  ["Retrieve Referral Letter PDF"]: 1077,
+  ["Update Referral Letter Content"]: 72,
+  ["Retrieve Referral Letter Edit Status"]: 144,
+  ["Update Referral Letter Address"]: 62,
+  ["Update Referral Letter to Approved"]: 1851,
+  ["Retrieve Final Referral Letter URL"]: 62,
+  // Other
+  ["Authorize API Backend"]: 395,
+  ["Update Recommended Actions"]: 139,
+  DEFAULT: 500
+};
+
+fs.readFile("output/letter-generation-test-stats.csv", "utf8", (err, data) => {
+  if (err) {
+    console.error("failed reading letter-generation-test-stats.csv", err);
+    process.exit(1);
+  }
+
+  let failure = false;
+  data
+    .split("\n")
+    .map(row => {
+      let [operation, status, latency] = row.split(",");
+      return { operation, status, latency };
+    })
+    .filter(res => res.operation && res.operation !== "operation")
+    .forEach(res => {
+      let threshold = THRESHOLDS.DEFAULT;
+      if (THRESHOLDS[res.operation]) {
+        threshold = THRESHOLDS[res.operation];
+      }
+
+      if (res.latency > threshold) {
+        failure = true;
+        console.error(
+          `ERROR - operation: ${res.operation} took ${res.latency}ms, which is above its threshold of ${threshold}ms`
+        );
+      } else {
+        console.log(
+          `operation: ${res.operation} passed its threshold (${res.latency}ms < ${threshold}ms)`
+        );
+      }
+    });
+
+  if (failure) {
+    console.error("latency validation failed (see above)");
+    process.exit(1);
+  }
+});

--- a/scripts/extractTestLatency.sh
+++ b/scripts/extractTestLatency.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "operation,response code,latency (ms)"
+previous_line=''
+while read line;
+do
+    if [[ $line =~ ([A-Z]+ [^ ]+).*\[([0-9]{3}).*B[^0-9]*([0-9]+)ms\] ]]
+    then
+        echo "${previous_line:4},${BASH_REMATCH[2]},${BASH_REMATCH[3]}"
+    fi
+    previous_line=$line
+done <output/newman-result.txt


### PR DESCRIPTION
This change uses scripts to pull run times from the letter-generation CI pipeline job and asserts that they are below given thresholds